### PR TITLE
Shouldn't revert the color when you do a clickout on a flat picker 

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -655,7 +655,7 @@
             if (clickoutFiresChange) {
                 updateOriginalInput(true);
             }
-            else {
+            else if (!flat) {
                 revert();
             }
             hide();


### PR DESCRIPTION
Flat picker stays visible on screen so it never sets the colorOnShow after it is already created.  Every time you click outside the flat picker it reverts back to the color it had on creation.
